### PR TITLE
Fix copy-paste errors in Animals README

### DIFF
--- a/Examples/Image/DataSets/Animals/README.md
+++ b/Examples/Image/DataSets/Animals/README.md
@@ -1,12 +1,12 @@
 # Animals Dataset
 
-The Animals dataset is a small toy data set that contains license free images of mainly wolfs and sheep which were taken from the internet.
+The Animals dataset is a small toy data set that contains license free images of mainly wolves and sheep which were taken from the internet.
 
 The Animals dataset is not included in the CNTK distribution but can be easily
-downloaded by cd to this directory, Examples/Image/DataSets/Grocery and running the following Python command:
+downloaded by cd to this directory, Examples/Image/DataSets/Animals and running the following Python command:
 
-`python install_grocery.py`
+`python install_animals.py`
 
 After running the script, you will see two folders with images (Train and Test). 
 
-The grocery dataset is for example used in the Transfer Learning example, see [here](https://github.com/Microsoft/CNTK/wiki/Build-your-own-image-classifier-using-Transfer-Learning).
+The animals dataset is used in the Transfer Learning example, see [here](https://github.com/Microsoft/CNTK/wiki/Build-your-own-image-classifier-using-Transfer-Learning).


### PR DESCRIPTION
Readme looks like it was copied from Grocery dataset, just fixing the references and cleaning up a few minor things.